### PR TITLE
Fix  AWS deployment

### DIFF
--- a/.github/workflows/deploy-to-aws.yaml
+++ b/.github/workflows/deploy-to-aws.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: yarn install
         run: yarn install
 
+      - name: Install commandline tools
+        run: npm install -g expo-cli sharp-cli
+
       - name: Build Client JavaScript
         run: npm run build:client
 
@@ -36,23 +39,23 @@ jobs:
       - name: Create secret environment variables
         uses: SpicyPizza/create-envfile@v1
         with:
-          SEGMENT_ANALYTICS_WRITE_KEY: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
-          MONGODB_USER_0_PASSWORD: ${{ secrets.MONGODB_USER_0_PASSWORD }}
-          GRAPHQL_URI: "/graphql"
-          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          envkey_GRAPHQL_URI: "/graphql"
+          envkey_MONGODB_USER_0_PASSWORD: ${{ secrets.MONGODB_USER_0_PASSWORD }}
+          envkey_SEGMENT_ANALYTICS_WRITE_KEY: ${{ secrets.SEGMENT_ANALYTICS_WRITE_KEY }}
+          envkey_SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
 
       - name: Create deployment package
         run:
           zip -r deploy.zip server-build web-build node_modules package.json
-          .env assets
+          .env yarn.lock assets
 
       - name: Deploy to EB
         uses: einaregilsson/beanstalk-deploy@v19
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          application_name: aid-app-${{ github.ref_name }}-2
-          environment_name: aid-app-${{ github.ref_name }}-2-env
+          application_name: aid-app-monorepo-${{ github.ref_name }}
+          environment_name: aid-app-monorepo-${{ github.ref_name }}-env
           version_label: ${{ github.ref_name }}.${{ github.sha }}
           region: us-east-2
           deployment_package: deploy.zip


### PR DESCRIPTION
[![AWS](https://github.com/dandelion-community/aid-app-monorepo/actions/workflows/deploy-to-aws.yaml/badge.svg?branch=chris)](https://github.com/dandelion-community/aid-app-monorepo/actions/workflows/deploy-to-aws.yaml)

1. [Successful action run](https://github.com/dandelion-community/aid-app-monorepo/runs/4611374089?check_suite_focus=true)
2. [This is the auto-created deployment](http://chris.dandelion.supplies)
2. The main problem was that I didn't use the "envkey_" prefix properly as described in [the documentation for the create-envfile action](https://github.com/SpicyPizza/create-envfile)
3. We also need to install expo-cli in order to generate the client code
4. It's helpful to add yarn.lock to the zip file so that the aws node environment doesn't change module versions
5. We can go back to using the old environment names since there wasn't actually anything "broken" about the old environments (as was my suspicion.) It's just that the deployment versions were broken