### PR TITLE
Gate all GraphQL calls to logged-in users

### DIFF
--- a/src/server/graphql/assertLoggedIn.ts
+++ b/src/server/graphql/assertLoggedIn.ts
@@ -1,0 +1,34 @@
+import type { GraphQLResolveInfo } from 'graphql';
+import type { ResolverMiddleware } from 'graphql-compose';
+
+export default function assertLoggedIn(
+  req: Express.Request,
+  what: string,
+): Express.User {
+  const { user } = req;
+  if (user == null) {
+    throw new Error('You must be logged in for action ' + what);
+  }
+  return user;
+}
+
+export function createAssertLoggedInMiddleware<TSource, TArgs, TOut>(
+  what: string,
+): ResolverMiddleware<TSource, Express.Request, TArgs> {
+  function assertLoggedInMiddleware(
+    resolve: (
+      source: TSource,
+      args: TArgs,
+      req: Express.Request,
+      info: GraphQLResolveInfo,
+    ) => TOut,
+    source: TSource,
+    args: TArgs,
+    req: Express.Request,
+    info: GraphQLResolveInfo,
+  ): TOut {
+    assertLoggedIn(req, what);
+    return resolve(source, args, req, info);
+  }
+  return assertLoggedInMiddleware;
+}

--- a/src/server/objects/aid_request/AidRequestGraphQLImpl.ts
+++ b/src/server/objects/aid_request/AidRequestGraphQLImpl.ts
@@ -1,3 +1,4 @@
+import { createAssertLoggedInMiddleware } from '../../graphql/assertLoggedIn';
 import { AidRequestGraphQLType } from './AidRequestGraphQLTypes';
 import createAidRequest from './mutations/createAidRequest';
 import updateIsAidRequestComplete from './mutations/updateIsAidRequestComplete';
@@ -15,7 +16,9 @@ const AidRequest = {
     updateWhetherIAmWorkingOnThisAidRequest,
   },
   QueryFields: {
-    allAidRequests: AidRequestGraphQLType.getResolver('connection'),
+    allAidRequests: AidRequestGraphQLType.getResolver('connection', [
+      createAssertLoggedInMiddleware('allAidRequests'),
+    ]),
   },
 };
 

--- a/src/server/objects/aid_request/mutations/createAidRequest.ts
+++ b/src/server/objects/aid_request/mutations/createAidRequest.ts
@@ -1,3 +1,4 @@
+import assertLoggedIn from '../../../graphql/assertLoggedIn';
 import { AidRequestGraphQLType } from '../AidRequestGraphQLTypes';
 import { AidRequestModel } from '../AidRequestModel';
 import type { AidRequestType } from '../AidRequestModelTypes';
@@ -13,10 +14,7 @@ async function createAidRequestResolver(
   },
   req: Express.Request,
 ): Promise<AidRequestType> {
-  const { user } = req;
-  if (user == null) {
-    throw new Error('You must be logged in to create a request');
-  }
+  const user = assertLoggedIn(req, 'Create aid request');
   const whoRecordedItUsername = user.username;
   const aidRequest = new AidRequestModel({
     completed: false,

--- a/src/server/objects/aid_request/mutations/updateIsAidRequestComplete.ts
+++ b/src/server/objects/aid_request/mutations/updateIsAidRequestComplete.ts
@@ -1,3 +1,4 @@
+import assertLoggedIn from '../../../graphql/assertLoggedIn';
 import { AidRequestGraphQLType } from '../AidRequestGraphQLTypes';
 import { AidRequestModel } from '../AidRequestModel';
 import type { AidRequestType } from '../AidRequestModelTypes';
@@ -7,10 +8,7 @@ async function updateIsAidRequestCompleteResolver(
   { id, newValue }: { id: string; newValue: boolean },
   req: Express.Request,
 ): Promise<AidRequestType | null> {
-  const { user } = req;
-  if (user == null) {
-    throw new Error('You must be logged in to create a request');
-  }
+  assertLoggedIn(req, 'Update is aid request complete');
   return await AidRequestModel.findOneAndUpdate(
     { _id: id },
     { completed: newValue },

--- a/src/server/objects/aid_request/mutations/updateWhetherIAmWorkingOnThisAidRequest.ts
+++ b/src/server/objects/aid_request/mutations/updateWhetherIAmWorkingOnThisAidRequest.ts
@@ -1,5 +1,6 @@
 import { ObjectId } from 'mongodb';
 import mongoose from 'mongoose';
+import assertLoggedIn from '../../../graphql/assertLoggedIn';
 import { AidRequestGraphQLType } from '../AidRequestGraphQLTypes';
 import { AidRequestModel } from '../AidRequestModel';
 import type { AidRequestType } from '../AidRequestModelTypes';
@@ -23,12 +24,10 @@ async function updateWhetherIAmWorkingOnThisAidRequestResolver(
   }: { aidRequestID: string; iAmWorkingOnIt: boolean },
   req: Express.Request,
 ): Promise<AidRequestType | null> {
-  const { user } = req;
-  if (user == null) {
-    throw new Error(
-      'You must be logged in to add a person who is working on it',
-    );
-  }
+  const user = assertLoggedIn(
+    req,
+    'Update whether I am working on this aid request',
+  );
   const { _id: userID } = user;
 
   await mongoose.connection.db.collection('userInfo').updateOne(

--- a/src/server/objects/aid_request/object_fields/whoIsWorkingOnItUsers.ts
+++ b/src/server/objects/aid_request/object_fields/whoIsWorkingOnItUsers.ts
@@ -1,19 +1,22 @@
 import type { ObjectTypeComposerFieldConfigAsObjectDefinition } from 'graphql-compose';
 import { Document } from 'mongoose';
 import filterNulls from '../../../../shared/utils/filterNulls';
+import assertLoggedIn from '../../../graphql/assertLoggedIn';
 import { UserModel } from '../../user/UserModel';
 import { AidRequestModel } from '../AidRequestModel';
 import type { AidRequestType } from '../AidRequestModelTypes';
 
 const whoIsWorkingOnItUsers: ObjectTypeComposerFieldConfigAsObjectDefinition<
   Document<string, unknown, AidRequestType>,
-  unknown
+  Express.Request,
+  Record<string, never>
 > = {
-  resolve: async ({
-    _id,
-  }: Document<string, unknown, AidRequestType>): Promise<
-    Array<Express.User>
-  > => {
+  resolve: async (
+    { _id }: Document<string, unknown, AidRequestType>,
+    _args: Record<string, never>,
+    req: Express.Request,
+  ): Promise<Array<Express.User>> => {
+    assertLoggedIn(req, 'whoIsWorkingOnItUsers');
     const aidRequest = await AidRequestModel.findById(_id);
     if (aidRequest == null) {
       return [];

--- a/src/server/objects/user/object_fields/aidRequestsIAmWorkingOn.ts
+++ b/src/server/objects/user/object_fields/aidRequestsIAmWorkingOn.ts
@@ -2,20 +2,23 @@ import type { ObjectTypeComposerFieldConfigAsObjectDefinition } from 'graphql-co
 import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
 import filterNulls from '../../../../shared/utils/filterNulls';
+import assertLoggedIn from '../../../graphql/assertLoggedIn';
 import { AidRequestModel } from '../../aid_request/AidRequestModel';
 import type { AidRequestType } from '../../aid_request/AidRequestModelTypes';
 import { UserModel } from '../UserModel';
 
 const aidRequestsIAmWorkingOn: ObjectTypeComposerFieldConfigAsObjectDefinition<
   Express.User,
-  unknown
+  Express.Request,
+  Record<string, never>
 > = {
-  resolve: async ({
-    _id,
-  }: Express.User): Promise<
-    Array<Document<string, unknown, AidRequestType>>
-  > => {
-    const dbUser = await UserModel.findById(_id);
+  resolve: async (
+    { _id: userID }: Express.User,
+    _args: Record<string, never>,
+    req: Express.Request,
+  ): Promise<Array<Document<string, unknown, AidRequestType>>> => {
+    assertLoggedIn(req, 'aidRequestsIAmWorkingOn');
+    const dbUser = await UserModel.findById(userID);
     if (dbUser == null) {
       return [];
     }


### PR DESCRIPTION
For security/privacy purposes, only logged-in users should be able to access data through GraphQL. The exceptions are `login`, `register`, `logout`, and `me`

https://user-images.githubusercontent.com/4309735/148564320-9588290e-74fb-41ff-adb3-ab578eb24ddc.mov


