### PR TITLE
Local cache update on request mutation

### DIFF
--- a/src/client/aid-app/aid_requests/AidRequestCardFragments.ts
+++ b/src/client/aid-app/aid_requests/AidRequestCardFragments.ts
@@ -15,6 +15,7 @@ export const AidRequestWorkingOnItSummaryFragments = {
       _id
       whoIsWorkingOnItUsers {
         username
+        _id
       }
     }
   `,

--- a/src/client/aid-app/aid_requests/AidRequestCompleteToggle.tsx
+++ b/src/client/aid-app/aid_requests/AidRequestCompleteToggle.tsx
@@ -1,9 +1,9 @@
 import { gql, useMutation } from '@apollo/client';
 import * as React from 'react';
 import { Paragraph, Switch } from 'react-native-paper';
-import client from '../../aid-app/graphql/client';
 import { AidRequestCardFragments } from './AidRequestCardFragments';
 import AidRequestCardSection from './AidRequestCardSection';
+import { broadcastAidRequestUpdated } from './AidRequestFilterLocalCacheUpdater';
 import type { AidRequestIsCompleteToggleFragment } from './__generated__/AidRequestIsCompleteToggleFragment';
 import type {
   updateIsAidRequestCompleteMutation,
@@ -54,14 +54,13 @@ export default function AidRequestIsCompleteToggle({
   async function onToggleSwitch(): Promise<void> {
     const newValue = !displayValue;
     setOptimisticValue(newValue);
-    await runUpdateIsRequestCompleteMutation({
+    const { data } = await runUpdateIsRequestCompleteMutation({
       variables: {
         id,
         newValue,
       },
     });
-    await client.clearStore();
-    await client.refetchQueries({ include: ['ListOfAidRequestsQuery'] });
+    broadcastAidRequestUpdated(data?.updateIsAidRequestComplete);
   }
 }
 

--- a/src/client/aid-app/aid_requests/AidRequestFilterLocalCacheUpdater.ts
+++ b/src/client/aid-app/aid_requests/AidRequestFilterLocalCacheUpdater.ts
@@ -1,0 +1,128 @@
+import client from '../graphql/client';
+import type { FilterType } from '../navigation/screens/main/request_explorer/filters/RequestExplorerFiltersContext';
+import { FILTERS } from '../navigation/screens/main/request_explorer/RequestExplorerFilters';
+import {
+  LIST_OF_AID_REQUESTS_QUERY,
+  PAGE_SIZE,
+} from './ListOfAidRequestsQuery';
+import {
+  ListOfAidRequestsQuery,
+  ListOfAidRequestsQueryVariables,
+  ListOfAidRequestsQuery_allAidRequests_edges,
+  ListOfAidRequestsQuery_allAidRequests_edges_node,
+} from './__generated__/ListOfAidRequestsQuery';
+
+type SubscriberEntry = {
+  data: ListOfAidRequestsQuery;
+  filter: FilterType;
+};
+
+const SUBSCRIBERS: Map<string, SubscriberEntry> = new Map();
+
+export function subscribeQueryToAidRequestUpdates(
+  filter: FilterType,
+  data: ListOfAidRequestsQuery,
+): void {
+  SUBSCRIBERS.set(JSON.stringify(filter), { data, filter });
+}
+
+export function broadcastAidRequestUpdated(
+  aidRequest:
+    | ListOfAidRequestsQuery_allAidRequests_edges_node
+    | undefined
+    | null,
+): void {
+  if (aidRequest == null) {
+    console.error('Unexpected null');
+    return;
+  }
+  SUBSCRIBERS.forEach((entry: SubscriberEntry): void => {
+    processAidRequestUpdateForQuery(entry, aidRequest);
+  });
+}
+
+function processAidRequestUpdateForQuery(
+  { filter, data: list }: SubscriberEntry,
+  aidRequest: ListOfAidRequestsQuery_allAidRequests_edges_node,
+): void {
+  if (passesFilter(filter, aidRequest)) {
+    addAidRequestIfNotPresent(filter, list, aidRequest);
+  } else {
+    removeAidRequestIfPresent(filter, list, aidRequest);
+  }
+}
+
+function passesFilter(
+  filter: FilterType,
+  aidRequest: ListOfAidRequestsQuery_allAidRequests_edges_node,
+): boolean {
+  return FILTERS.every(({ passes }) => passes(filter, aidRequest));
+}
+
+function addAidRequestIfNotPresent(
+  filter: FilterType,
+  list: ListOfAidRequestsQuery,
+  aidRequest: ListOfAidRequestsQuery_allAidRequests_edges_node,
+): void {
+  const { _id: aidRequestID } = aidRequest;
+  if (
+    list.allAidRequests?.edges.some((edge) => edge.node._id === aidRequestID)
+  ) {
+    return;
+  }
+  const oldEdges = list.allAidRequests?.edges ?? [];
+  const newEdges: ListOfAidRequestsQuery_allAidRequests_edges[] = [
+    {
+      __typename: 'AidRequestEdge',
+      node: aidRequest,
+    },
+    ...oldEdges,
+  ];
+  publishNewEdges(filter, newEdges, list);
+}
+
+function removeAidRequestIfPresent(
+  filter: FilterType,
+  list: ListOfAidRequestsQuery,
+  aidRequest: ListOfAidRequestsQuery_allAidRequests_edges_node,
+): void {
+  const { _id: aidRequestID } = aidRequest;
+  if (
+    !list.allAidRequests?.edges.some((edge) => edge.node._id === aidRequestID)
+  ) {
+    return;
+  }
+  const oldEdges = list.allAidRequests?.edges ?? [];
+  const newEdges: ListOfAidRequestsQuery_allAidRequests_edges[] =
+    oldEdges.filter((edge) => edge.node._id !== aidRequestID);
+  publishNewEdges(filter, newEdges, list);
+}
+
+function publishNewEdges(
+  filter: FilterType,
+  edges: ListOfAidRequestsQuery_allAidRequests_edges[],
+  list: ListOfAidRequestsQuery,
+): void {
+  const data: ListOfAidRequestsQuery = {
+    allAidRequests: {
+      __typename: 'AidRequestConnection',
+      edges,
+      pageInfo: list.allAidRequests?.pageInfo ?? {
+        __typename: 'PageInfo',
+        endCursor: null,
+        hasNextPage: true,
+      },
+    },
+  };
+  client.cache.writeQuery<
+    ListOfAidRequestsQuery,
+    ListOfAidRequestsQueryVariables
+  >({
+    broadcast: true,
+    data,
+    overwrite: true,
+    query: LIST_OF_AID_REQUESTS_QUERY,
+    variables: { after: null, filter, pageSize: PAGE_SIZE },
+  });
+  subscribeQueryToAidRequestUpdates(filter, data);
+}

--- a/src/client/aid-app/aid_requests/ListOfAidRequestsQuery.ts
+++ b/src/client/aid-app/aid_requests/ListOfAidRequestsQuery.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+import { AidRequestCardFragments } from './AidRequestCardFragments';
+
+export const PAGE_SIZE = 5;
+
+export const LIST_OF_AID_REQUESTS_QUERY = gql`
+  query ListOfAidRequestsQuery(
+    $pageSize: Int!
+    $after: String
+    $filter: FilterFindManyAidRequestInput
+  ) {
+    allAidRequests(first: $pageSize, after: $after, filter: $filter) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          ...AidRequestCardFragment
+        }
+      }
+    }
+  }
+  ${AidRequestCardFragments.aidRequest}
+`;

--- a/src/client/aid-app/aid_requests/__generated__/AidRequestCardFragment.ts
+++ b/src/client/aid-app/aid_requests/__generated__/AidRequestCardFragment.ts
@@ -10,6 +10,7 @@
 export interface AidRequestCardFragment_whoIsWorkingOnItUsers {
   __typename: "User";
   username: string | null;
+  _id: string;
 }
 
 export interface AidRequestCardFragment {

--- a/src/client/aid-app/aid_requests/__generated__/ListOfAidRequestsQuery.ts
+++ b/src/client/aid-app/aid_requests/__generated__/ListOfAidRequestsQuery.ts
@@ -24,6 +24,7 @@ export interface ListOfAidRequestsQuery_allAidRequests_pageInfo {
 export interface ListOfAidRequestsQuery_allAidRequests_edges_node_whoIsWorkingOnItUsers {
   __typename: "User";
   username: string | null;
+  _id: string;
 }
 
 export interface ListOfAidRequestsQuery_allAidRequests_edges_node {

--- a/src/client/aid-app/aid_requests/__generated__/updateIsAidRequestCompleteMutation.ts
+++ b/src/client/aid-app/aid_requests/__generated__/updateIsAidRequestCompleteMutation.ts
@@ -10,6 +10,7 @@
 export interface updateIsAidRequestCompleteMutation_updateIsAidRequestComplete_whoIsWorkingOnItUsers {
   __typename: "User";
   username: string | null;
+  _id: string;
 }
 
 export interface updateIsAidRequestCompleteMutation_updateIsAidRequestComplete {

--- a/src/client/aid-app/navigation/screens/main/request_explorer/RequestExplorerFilterButton.tsx
+++ b/src/client/aid-app/navigation/screens/main/request_explorer/RequestExplorerFilterButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import Text from '../../../../../general-purpose/components/light-or-dark-themed/Text';
 import { useLoggedInViewer } from '../../../../../general-purpose/viewer/ViewerContext';
+import { ListOfAidRequestsQuery_allAidRequests_edges_node } from '../../../../aid_requests/__generated__/ListOfAidRequestsQuery';
 import type { FilterType } from './filters/RequestExplorerFiltersContext';
 import { useRequestExplorerFilters } from './filters/RequestExplorerFiltersContext';
 
@@ -20,6 +21,10 @@ export type FilterButtonProps = {
     context: FilterContext,
   ) => boolean;
   label: string;
+  passes: (
+    filter: FilterType,
+    aidRequest: ListOfAidRequestsQuery_allAidRequests_edges_node,
+  ) => boolean;
   toggleOff: UpdateFilter;
   toggleOn: UpdateFilter;
 };

--- a/src/client/aid-app/navigation/screens/main/request_explorer/RequestExplorerScreen.tsx
+++ b/src/client/aid-app/navigation/screens/main/request_explorer/RequestExplorerScreen.tsx
@@ -4,11 +4,14 @@ import View from '../../../../../general-purpose/components/light-or-dark-themed
 import RequireLoggedInScreen from '../../../../../general-purpose/components/RequireLoggedInScreen';
 import ListOfRequests from '../../../../aid_requests/ListOfAidRequests';
 import type { FilterType } from './filters/RequestExplorerFiltersContext';
-import { RequestExplorerFiltersContext } from './filters/RequestExplorerFiltersContext';
+import {
+  DEFAULT_FILTER,
+  RequestExplorerFiltersContext,
+} from './filters/RequestExplorerFiltersContext';
 import RequestExplorerFilters from './RequestExplorerFilters';
 
 export default function RequestExplorerScreen(): JSX.Element {
-  const [filter, setFilters] = React.useState<FilterType>({ completed: false });
+  const [filter, setFilters] = React.useState<FilterType>(DEFAULT_FILTER);
 
   return (
     <RequireLoggedInScreen>

--- a/src/client/aid-app/navigation/screens/main/request_explorer/filters/RequestExplorerFiltersContext.ts
+++ b/src/client/aid-app/navigation/screens/main/request_explorer/filters/RequestExplorerFiltersContext.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import type { ListOfAidRequestsQueryVariables } from '../../../../../aid_requests/__generated__/ListOfAidRequestsQuery';
 
-export type FilterType = ListOfAidRequestsQueryVariables['filter'];
+export type FilterType = NonNullable<ListOfAidRequestsQueryVariables['filter']>;
+
+export const DEFAULT_FILTER: FilterType = { completed: false };
 
 export type Filters = {
   filter: FilterType;
@@ -9,7 +11,7 @@ export type Filters = {
 };
 
 export const RequestExplorerFiltersContext = React.createContext<Filters>({
-  filter: null,
+  filter: DEFAULT_FILTER,
   setFilters: () => undefined,
 });
 


### PR DESCRIPTION
When you change the "completed" or "working on" field on a request, we should automatically update the cache entries for any aid request lists that have already been loaded. For example, if we've loaded a list of "Completed" requests and a list of "Completed by Me" requests (only one of which is rendering right now), if you mark a request as "Incomplete", then it should be removed from both lists -- both the one that's rendering right now, and the one that will render when you change your filter (to add/remove the "Me" filter.) 

https://user-images.githubusercontent.com/4309735/148649867-e506087e-ce51-471e-85a1-bbf644f98107.mov


